### PR TITLE
支持多种屏幕的可访问性

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "version": "0.0.0",
   "type": "module",
   "scripts": {
-    "dev": "vite",
+    "dev": "vite --host",
     "build": "tsc && vite build",
     "preview": "vite preview"
   },
@@ -22,7 +22,7 @@
     "less": "^4.1.3",
     "less-loader": "^11.1.0",
     "path": "^0.12.7",
-    "postcss-px-to-viewport": "^1.1.1",
+    "postcss-mobile-forever": "^2.3.3",
     "typescript": "^4.9.3",
     "vite": "^4.1.0"
   }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,12 +1,21 @@
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
 import path from 'path'
-import pxtovw from 'postcss-px-to-viewport'
+import viewport from 'postcss-mobile-forever'
 
-const loder_pxtovw = pxtovw({
-  viewportWidth: 375,
-  viewportUnit: 'vw',
-  propList: ['*'], // 指定转换的css属性的单位，*代表全部css属性的单位都进行转换
+const loader_viewport = viewport({
+  rootSelector: "#root",
+  viewportWidth: 375, // 设计稿宽度
+  maxDisplayWidth: null, // 限制视口单位最大宽度
+  propList: ['*'],
+  disableDesktop: false, // 关闭桌面端媒体查询适配
+  disableLandscape: false, // 关闭横屏媒体查询适配
+  border: true, // 桌面端和横屏展示边框
+  mobileConfig: {
+    viewportUnit: 'vw', // 移动端单位
+    replace: true, // 是否替换
+    fontViewportUnit: 'vw', // 移动端字体单位
+  }
 })
 
 // https://vitejs.dev/config/
@@ -14,7 +23,7 @@ export default defineConfig({
   plugins: [react()],
   css: {
     postcss: {
-      plugins: [loder_pxtovw],
+      plugins: [loader_viewport],
     },
   },
   resolve: {

--- a/yarn.lock
+++ b/yarn.lock
@@ -876,11 +876,6 @@ node-releases@^2.0.8:
   resolved "https://registry.npmmirror.com/node-releases/-/node-releases-2.0.10.tgz#c311ebae3b6a148c89b1813fd7c4d3c024ef537f"
   integrity sha512-5GFldHPXVG/YZmFzJvKK2zDSzPKhEp0+ZR5SVaoSag9fsL5YgHbUHDfnG5494ISANDcK4KwPXAx2xqVEydmd7w==
 
-object-assign@>=4.0.1:
-  version "4.1.1"
-  resolved "https://registry.npmmirror.com/object-assign/-/object-assign-4.1.1.tgz#2109adc7965887cfc05cbbd442cac8bfbb360863"
-  integrity sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==
-
 parse-node-version@^1.0.1:
   version "1.0.1"
   resolved "https://registry.npmmirror.com/parse-node-version/-/parse-node-version-1.0.1.tgz#e2b5dbede00e7fa9bc363607f53327e8b073189b"
@@ -909,15 +904,12 @@ pify@^4.0.1:
   resolved "https://registry.npmmirror.com/pify/-/pify-4.0.1.tgz#4b2cd25c50d598735c50292224fd8c6df41e3231"
   integrity sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==
 
-postcss-px-to-viewport@^1.1.1:
-  version "1.1.1"
-  resolved "https://registry.npmmirror.com/postcss-px-to-viewport/-/postcss-px-to-viewport-1.1.1.tgz#a25ca410b553c9892cc8b525cc710da47bf1aa55"
-  integrity sha512-2x9oGnBms+e0cYtBJOZdlwrFg/mLR4P1g2IFu7jYKvnqnH/HLhoKyareW2Q/x4sg0BgklHlP1qeWo2oCyPm8FQ==
-  dependencies:
-    object-assign ">=4.0.1"
-    postcss ">=5.0.2"
+postcss-mobile-forever@^2.3.3:
+  version "2.3.3"
+  resolved "https://registry.yarnpkg.com/postcss-mobile-forever/-/postcss-mobile-forever-2.3.3.tgz#2280962c0d0f946f59060bcad91dee2ef211791d"
+  integrity sha512-Zch37T6oxypIQcz/SXHZvEeCGC5Grk0dfMCwY3MGEuRGc1syvvzQKIbAyel+r//45EZlsWzs+Zs5TkCQRAVZ7A==
 
-postcss@>=5.0.2, postcss@^8.4.21:
+postcss@^8.4.21:
   version "8.4.21"
   resolved "https://registry.npmmirror.com/postcss/-/postcss-8.4.21.tgz#c639b719a57efc3187b13a1d765675485f4134f4"
   integrity sha512-tP7u/Sn/dVxK2NnruI4H9BG+x+Wxz6oeZ1cJ8P6G/PZY0IKk4k/63TDsQf2kQq3+qoJeLm2kIBUNlZe3zgb4Zg==


### PR DESCRIPTION
zhoushan 你好啊，欢迎试下我最近开发的插件，[postcss-mobile-forever](https://github.com/wswmsword/postcss-mobile-forever)。

这个插件可以让移动端视图展示在桌面端和横屏，可以限制视口单位 vw 的最大宽度。插件支持 PostCSS 8，这样控制台不会警告，插件支持向 viewportWidth 传递函数，可以生成动态视图宽度，所以未来加入不同视图宽度的库也能兼容。另外插件基本支持 postcss-px-to-viewport 的功能，都通过了单元测试。

欢迎使用啊～插件持续维护～